### PR TITLE
Implemented runtime timer command

### DIFF
--- a/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj
+++ b/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj
@@ -1,479 +1,484 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup Label="ProjectConfigurations">
-		<ProjectConfiguration Include="Debug|Win32">
-			<Configuration>Debug</Configuration>
-			<Platform>Win32</Platform>
-		</ProjectConfiguration>
-	</ItemGroup>
-	<PropertyGroup Label="Globals">
-		<ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
-		<ProjectName>aws_demos</ProjectName>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props"/>
-	<PropertyGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;" Label="Configuration">
-		<ConfigurationType>Application</ConfigurationType>
-		<UseOfMfc>false</UseOfMfc>
-		<CharacterSet>Unicode</CharacterSet>
-		<PlatformToolset>v141</PlatformToolset>
-	</PropertyGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props"/>
-	<ImportGroup Label="ExtensionSettings"/>
-	<ImportGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;" Label="PropertySheets">
-		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists(&apos;$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props&apos;)" Label="LocalAppDataPlatform"/>
-		<Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props"/>
-	</ImportGroup>
-	<PropertyGroup Label="UserMacros"/>
-	<PropertyGroup>
-		<_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-		<OutDir Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;">.\Debug\</OutDir>
-		<IntDir Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;">.\Debug\</IntDir>
-		<LinkIncremental Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;">true</LinkIncremental>
-		<CodeAnalysisRuleSet Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;">AllRules.ruleset</CodeAnalysisRuleSet>
-	</PropertyGroup>
-	<ItemDefinitionGroup Condition="&apos;$(Configuration)|$(Platform)&apos;==&apos;Debug|Win32&apos;">
-		<Midl>
-			<TypeLibraryName>.\Debug/WIN32.tlb</TypeLibraryName>
-			<HeaderFileName/>
-		</Midl>
-		<ClCompile>
-			<Optimization>Disabled</Optimization>
-			<AdditionalIncludeDirectories>..\..\..\..\..\freertos_kernel\include;..\..\..\..\..\freertos_kernel\portable\MSVC-MingW;..\..\..\..\..\vendors\pc\boards\windows\aws_demos\config_files;..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code;..\..\..\..\..\demos\include;..\..\..\..\..\demos\network_manager;..\..\..\..\..\libraries\c_sdk\standard\common\include\private;..\..\..\..\..\libraries\c_sdk\standard\common\include;..\..\..\..\..\libraries\abstractions\platform\include;..\..\..\..\..\libraries\abstractions\platform\freertos\include;..\..\..\..\..\libraries\abstractions\secure_sockets\include;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\test;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\Compiler\MSVC;..\..\..\..\..\libraries\freertos_plus\standard\tls\include;..\..\..\..\..\libraries\freertos_plus\standard\crypto\include;..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include;..\..\..\..\..\libraries\abstractions\pkcs11\include;..\..\..\..\..\libraries\freertos_plus\standard\utils\include;..\..\..\..\..\demos\dev_mode_key_provisioning\include;..\..\..\..\..\libraries\c_sdk\aws\defender\include;..\..\..\..\..\libraries\c_sdk\standard\mqtt\include;..\..\..\..\..\libraries\c_sdk\standard\serializer\include;..\..\..\..\..\libraries\c_sdk\aws\shadow\include;..\..\..\..\..\libraries\c_sdk\standard\https\include;..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include;..\..\..\..\..\libraries\freertos_plus\aws\ota\src;..\..\..\..\..\libraries\freertos_plus\aws\ota\include;..\..\..\..\..\libraries\3rdparty\mbedtls\include;..\..\..\..\..\libraries\abstractions\posix\include;..\..\..\..\..\vendors\pc\boards\windows\ports\posix;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include;..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\Include;..\..\..\..\..\libraries\3rdparty\win_pcap;..\..\..\..\..\libraries\3rdparty\pkcs11;..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls;..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls;..\..\..\..\..\libraries\3rdparty\mbedtls_utils;..\..\..\..\..\libraries\3rdparty\mbedtls_config;..\..\..\..\..\libraries\3rdparty\tinycbor\src;..\..\..\..\..\libraries\3rdparty\http_parser;..\..\..\..\..\libraries\3rdparty\jsmn</AdditionalIncludeDirectories>
-			<PreprocessorDefinitions>MBEDTLS_CONFIG_FILE=&quot;aws_mbedtls_config.h&quot;;CONFIG_MEDTLS_USE_AFR_MEMORY;WIN32;_DEBUG;__free_rtos__;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;__PRETTY_FUNCTION__=__FUNCTION__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<MinimalRebuild/>
-			<BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-			<RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
-			<PrecompiledHeaderOutputFile/>
-			<AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
-			<ObjectFileName>.\Debug/</ObjectFileName>
-			<ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
-			<WarningLevel>Level4</WarningLevel>
-			<SuppressStartupBanner>true</SuppressStartupBanner>
-			<DisableLanguageExtensions>false</DisableLanguageExtensions>
-			<DebugInformationFormat>EditAndContinue</DebugInformationFormat>
-			<AdditionalOptions>/wd4127 /wd4200 /wd4204 /wd4210 %(AdditionalOptions)</AdditionalOptions>
-			<BrowseInformation>true</BrowseInformation>
-			<PrecompiledHeader>NotUsing</PrecompiledHeader>
-			<ExceptionHandling>false</ExceptionHandling>
-			<CompileAs>CompileAsC</CompileAs>
-			<SDLCheck>true</SDLCheck>
-			<MultiProcessorCompilation>true</MultiProcessorCompilation>
-		</ClCompile>
-		<ResourceCompile>
-			<PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-			<Culture>0x0c09</Culture>
-		</ResourceCompile>
-		<Link>
-			<OutputFile>.\Debug/aws_demos.exe</OutputFile>
-			<SuppressStartupBanner>true</SuppressStartupBanner>
-			<GenerateDebugInformation>true</GenerateDebugInformation>
-			<ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
-			<SubSystem>Console</SubSystem>
-			<TargetMachine>MachineX86</TargetMachine>
-			<AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
-			<AdditionalLibraryDirectories>..\..\..\..\..\libraries\3rdparty\win_pcap</AdditionalLibraryDirectories>
-			<Profile>false</Profile>
-			<ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
-		</Link>
-		<Bscmake>
-			<SuppressStartupBanner>true</SuppressStartupBanner>
-			<OutputFile>.\Debug/WIN32.bsc</OutputFile>
-		</Bscmake>
-	</ItemDefinitionGroup>
-	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-	<ImportGroup Label="ExtensionTargets"/>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\FreeRTOS.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\StackMacros.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\atomic.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\croutine.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\deprecated_definitions.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\event_groups.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\list.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\message_buffer.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_prototypes.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_wrappers.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\portable.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\projdefs.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\queue.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\semphr.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\stack_macros.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\stream_buffer.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\task.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\timers.h"/>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\portmacro.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\network_manager\iot_network_manager_private.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_application_version.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential_keys.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_demo.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_iot_demo_network.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_ota_codesigner_certificate.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_config_common.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_demo_logging.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_demo_runner.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_appversion32.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_init.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_linear_containers.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_logging.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_task.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_setup.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_network_types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_taskpool.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_taskpool_types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_taskpool_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_clock.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_network.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_threads.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\types\iot_platform_types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_platform_types_freertos.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_metrics.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_network_freertos.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_config_defaults.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_wrapper_metrics.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_ARP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DHCP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DNS.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_errno_TCP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOSIPConfigDefaults.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP_Private.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Sockets.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Stream_Buffer.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_IP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_WIN.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_UDP_IP.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\IPTraceMacroDefaults.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkBufferManagement.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkInterface.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\include\iot_tls.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\include\iot_crypto.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include\iot_pkcs11.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\threading_alt.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\include\iot_pkcs11_pal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_system_init.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_pki_utils.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\dev_mode_key_provisioning\include\aws_dev_mode_key_provisioning.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\private\aws_iot_defender_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\include\aws_iot_defender.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_serializer.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_json_utils.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_iot_shadow.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow_config_defaults.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_shadow.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_ggd_config_defaults.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_greengrass_discovery.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_agent.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_pal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\errno.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\fcntl.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\mqueue.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\pthread.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sched.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\semaphore.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\signal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sys\types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\time.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\unistd.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\utils.h"/>
-		<ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\ports\posix\FreeRTOS_POSIX_portable.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_types.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_portable_default.h"/>
-		<ClInclude Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_tasks.h"/>
-		<ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aes.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aesni.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\arc4.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aria.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1write.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\base64.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bignum.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\blowfish.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bn_mul.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\camellia.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ccm.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\certs.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chacha20.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chachapoly.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\check_config.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cmac.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\compat-1.3.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\config.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ctr_drbg.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\debug.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\des.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\dhm.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdh.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdsa.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecjpake.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy_poll.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\error.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\gcm.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\havege.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hkdf.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hmac_drbg.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md2.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md4.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md5.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\memory_buffer_alloc.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net_sockets.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\nist_kw.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\oid.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\padlock.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pem.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs11.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs12.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs5.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_time.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_util.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\poly1305.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ripemd160.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha1.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha256.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha512.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cache.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ciphersuites.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cookie.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_internal.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ticket.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\threading.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\timing.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\version.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crl.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crt.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_csr.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\xtea.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11f.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11t.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.h"/>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.h"/>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\event_groups.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\list.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\queue.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\stream_buffer.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\tasks.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\timers.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\port.c"/>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MemMang\heap_4.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_network_addr.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_version.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_network_manager.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_demo_network.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_freertos.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_runner.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool_static_memory.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_clock_freertos.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_threads_freertos.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_metrics.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_network_freertos.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\secure_sockets\freertos_plus_tcp\iot_secure_sockets.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_ARP.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DHCP.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DNS.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_IP.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Sockets.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Stream_Buffer.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_WIN.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_UDP_IP.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement\BufferAllocation_2.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap\NetworkInterface.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\src\iot_tls.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\src\iot_crypto.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\src\iot_pkcs11.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\pkcs11\iot_pkcs11_pal.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\iot_pkcs11_mbedtls.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_system_init.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_pki_utils.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\aws_dev_mode_key_provisioning.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_api.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_collector.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_mqtt.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_v1.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_static_memory.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_subscription.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_decoder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_encoder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_decoder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_encoder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_serializer_static_memory.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_json_utils.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_api.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_operation.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_parser.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_static_memory.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_subscription.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_client.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_utils.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_greengrass_discovery.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\base64.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\ota\aws_ota_pal.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_clock.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_mqueue.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_barrier.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_cond.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_mutex.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_sched.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_semaphore.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_timer.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_unistd.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_utils.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\defender\aws_iot_demo_defender.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\greengrass_connectivity\aws_greengrass_discovery_demo.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_sync.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_async.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_sync.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_async.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_common.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\mqtt\iot_demo_mqtt.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\shadow\aws_iot_demo_shadow.c"/>
-		<ClCompile Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_task.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\main.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_entropy_hardware_poll.c"/>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_run-time-stats-utils.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcKernelPort.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcSnapshotRecorder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aes.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aesni.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\arc4.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aria.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1parse.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1write.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\bignum.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\blowfish.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\camellia.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ccm.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\certs.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chacha20.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chachapoly.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher_wrap.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cmac.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ctr_drbg.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\debug.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\des.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\dhm.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdh.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdsa.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecjpake.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp_curves.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy_poll.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\error.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\gcm.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\havege.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hkdf.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hmac_drbg.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md2.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md4.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md5.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md_wrap.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\memory_buffer_alloc.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\net_sockets.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\nist_kw.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\oid.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\padlock.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pem.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk_wrap.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs11.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs12.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs5.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkparse.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkwrite.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform_util.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\poly1305.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ripemd160.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa_internal.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha1.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha256.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha512.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cache.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ciphersuites.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cli.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cookie.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_srv.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ticket.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_tls.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\threading.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\timing.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version_features.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_create.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crl.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crt.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_csr.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_crt.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_csr.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\xtea.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_utils.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.c"/>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.c"/>
-	</ItemGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C686325E-3261-42F7-AEB1-DDE5280E1CEB}</ProjectGuid>
+    <ProjectName>aws_demos</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v142</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC60.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">.\Debug\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <CodeAnalysisRuleSet Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">AllRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/WIN32.tlb</TypeLibraryName>
+      <HeaderFileName />
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..\..\..\..\freertos_kernel\include;..\..\..\..\..\freertos_kernel\portable\MSVC-MingW;..\..\..\..\..\vendors\pc\boards\windows\aws_demos\config_files;..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code;..\..\..\..\..\demos\include;..\..\..\..\..\demos\network_manager;..\..\..\..\..\libraries\c_sdk\standard\common\include\private;..\..\..\..\..\libraries\c_sdk\standard\common\include;..\..\..\..\..\libraries\abstractions\platform\include;..\..\..\..\..\libraries\abstractions\platform\freertos\include;..\..\..\..\..\libraries\abstractions\secure_sockets\include;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\test;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\Compiler\MSVC;..\..\..\..\..\libraries\freertos_plus\standard\tls\include;..\..\..\..\..\libraries\freertos_plus\standard\crypto\include;..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include;..\..\..\..\..\libraries\abstractions\pkcs11\include;..\..\..\..\..\libraries\freertos_plus\standard\utils\include;..\..\..\..\..\demos\dev_mode_key_provisioning\include;..\..\..\..\..\libraries\c_sdk\aws\defender\include;..\..\..\..\..\libraries\c_sdk\standard\mqtt\include;..\..\..\..\..\libraries\c_sdk\standard\serializer\include;..\..\..\..\..\libraries\c_sdk\aws\shadow\include;..\..\..\..\..\libraries\c_sdk\standard\https\include;..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include;..\..\..\..\..\libraries\freertos_plus\aws\ota\src;..\..\..\..\..\libraries\freertos_plus\aws\ota\include;..\..\..\..\..\libraries\3rdparty\mbedtls\include;..\..\..\..\..\libraries\abstractions\posix\include;..\..\..\..\..\vendors\pc\boards\windows\ports\posix;..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include;..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\Include;..\..\..\..\..\libraries\3rdparty\win_pcap;..\..\..\..\..\libraries\3rdparty\pkcs11;..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls;..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls;..\..\..\..\..\libraries\3rdparty\mbedtls_utils;..\..\..\..\..\libraries\3rdparty\mbedtls_config;..\..\..\..\..\libraries\3rdparty\tinycbor\src;..\..\..\..\..\libraries\3rdparty\http_parser;..\..\..\..\..\libraries\3rdparty\jsmn</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="aws_mbedtls_config.h";CONFIG_MEDTLS_USE_AFR_MEMORY;WIN32;_DEBUG;__free_rtos__;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;__PRETTY_FUNCTION__=__FUNCTION__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild />
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeaderOutputFile />
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level4</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DisableLanguageExtensions>false</DisableLanguageExtensions>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/wd4127 /wd4200 /wd4204 /wd4210 %(AdditionalOptions)</AdditionalOptions>
+      <BrowseInformation>true</BrowseInformation>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <ExceptionHandling>false</ExceptionHandling>
+      <CompileAs>CompileAsC</CompileAs>
+      <SDLCheck>true</SDLCheck>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0c09</Culture>
+    </ResourceCompile>
+    <Link>
+      <OutputFile>.\Debug/aws_demos.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/WIN32.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <AdditionalDependencies>wpcap.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>..\..\..\..\..\libraries\3rdparty\win_pcap</AdditionalLibraryDirectories>
+      <Profile>false</Profile>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
+    </Link>
+    <Bscmake>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <OutputFile>.\Debug/WIN32.bsc</OutputFile>
+    </Bscmake>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\FreeRTOS.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\StackMacros.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\atomic.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\croutine.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\deprecated_definitions.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\event_groups.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\list.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\message_buffer.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_prototypes.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_wrappers.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\portable.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\projdefs.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\queue.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\semphr.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\stack_macros.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\stream_buffer.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\task.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\timers.h" />
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\portmacro.h" />
+    <ClInclude Include="..\..\..\..\..\demos\network_manager\iot_network_manager_private.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_application_version.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential_keys.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_demo.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_iot_demo_network.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_ota_codesigner_certificate.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_config_common.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_demo_logging.h" />
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_demo_runner.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_appversion32.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_init.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_linear_containers.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_logging.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_task.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_setup.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_network_types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_taskpool.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_taskpool_types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_taskpool_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_clock.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_network.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_threads.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\types\iot_platform_types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_platform_types_freertos.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_metrics.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_network_freertos.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_config_defaults.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_wrapper_metrics.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_ARP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DHCP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DNS.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_errno_TCP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOSIPConfigDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP_Private.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Sockets.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Stream_Buffer.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_WIN.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_UDP_IP.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\IPTraceMacroDefaults.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkBufferManagement.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkInterface.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\include\iot_tls.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\include\iot_crypto.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include\iot_pkcs11.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\threading_alt.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\include\iot_pkcs11_pal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_system_init.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_pki_utils.h" />
+    <ClInclude Include="..\..\..\..\..\demos\dev_mode_key_provisioning\include\aws_dev_mode_key_provisioning.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\private\aws_iot_defender_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\include\aws_iot_defender.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_serializer.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_json_utils.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_iot_shadow.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow_config_defaults.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_shadow.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_ggd_config_defaults.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_greengrass_discovery.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_agent.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_pal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\errno.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\fcntl.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\mqueue.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\pthread.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sched.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\semaphore.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\signal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sys\types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\time.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\unistd.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\utils.h" />
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\commandTask.h" />
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\runtimeTimer.h" />
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\ports\posix\FreeRTOS_POSIX_portable.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_types.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_portable_default.h" />
+    <ClInclude Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_tasks.h" />
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aes.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aesni.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\arc4.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aria.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1write.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\base64.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bignum.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\blowfish.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bn_mul.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\camellia.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ccm.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\certs.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chacha20.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chachapoly.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\check_config.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cmac.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\compat-1.3.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\config.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ctr_drbg.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\debug.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\des.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\dhm.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdh.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdsa.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecjpake.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy_poll.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\error.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\gcm.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\havege.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hkdf.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hmac_drbg.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md2.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md4.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md5.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\memory_buffer_alloc.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net_sockets.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\nist_kw.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\oid.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\padlock.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pem.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs11.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs12.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs5.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_time.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_util.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\poly1305.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ripemd160.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha1.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha256.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha512.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cache.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ciphersuites.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cookie.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_internal.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ticket.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\threading.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\timing.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\version.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crl.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crt.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_csr.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\xtea.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11f.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11t.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.h" />
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\event_groups.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\list.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\queue.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\stream_buffer.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\tasks.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\timers.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\port.c" />
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MemMang\heap_4.c" />
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_network_addr.c" />
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_version.c" />
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo.c" />
+    <ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_network_manager.c" />
+    <ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_demo_network.c" />
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_freertos.c" />
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_runner.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool_static_memory.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_clock_freertos.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_threads_freertos.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_metrics.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_network_freertos.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\secure_sockets\freertos_plus_tcp\iot_secure_sockets.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_ARP.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DHCP.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DNS.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_IP.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Sockets.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Stream_Buffer.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_WIN.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_UDP_IP.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement\BufferAllocation_2.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap\NetworkInterface.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\src\iot_tls.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\src\iot_crypto.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\src\iot_pkcs11.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\commandTask.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\runtimeTimer.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\pkcs11\iot_pkcs11_pal.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\iot_pkcs11_mbedtls.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_system_init.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_pki_utils.c" />
+    <ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\aws_dev_mode_key_provisioning.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_api.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_collector.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_mqtt.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_v1.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_static_memory.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_subscription.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_decoder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_encoder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_decoder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_encoder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_serializer_static_memory.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_json_utils.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_api.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_operation.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_parser.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_static_memory.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_subscription.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_client.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_utils.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_greengrass_discovery.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\base64.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\ota\aws_ota_pal.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_clock.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_mqueue.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_barrier.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_cond.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_mutex.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_sched.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_semaphore.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_timer.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_unistd.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_utils.c" />
+    <ClCompile Include="..\..\..\..\..\demos\defender\aws_iot_demo_defender.c" />
+    <ClCompile Include="..\..\..\..\..\demos\greengrass_connectivity\aws_greengrass_discovery_demo.c" />
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_sync.c" />
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_async.c" />
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_sync.c" />
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_async.c" />
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_common.c" />
+    <ClCompile Include="..\..\..\..\..\demos\mqtt\iot_demo_mqtt.c" />
+    <ClCompile Include="..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c" />
+    <ClCompile Include="..\..\..\..\..\demos\shadow\aws_iot_demo_shadow.c" />
+    <ClCompile Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_task.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\main.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_entropy_hardware_poll.c" />
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_run-time-stats-utils.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcKernelPort.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcSnapshotRecorder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aes.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aesni.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\arc4.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aria.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1parse.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1write.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\bignum.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\blowfish.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\camellia.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ccm.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\certs.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chacha20.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chachapoly.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher_wrap.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cmac.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ctr_drbg.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\debug.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\des.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\dhm.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdh.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdsa.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecjpake.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp_curves.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy_poll.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\error.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\gcm.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\havege.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hkdf.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hmac_drbg.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md2.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md4.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md5.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md_wrap.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\memory_buffer_alloc.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\net_sockets.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\nist_kw.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\oid.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\padlock.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pem.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk_wrap.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs11.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs12.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs5.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkparse.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkwrite.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform_util.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\poly1305.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ripemd160.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa_internal.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha1.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha256.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha512.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cache.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ciphersuites.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cli.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cookie.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_srv.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ticket.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_tls.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\threading.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\timing.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version_features.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_create.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crl.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crt.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_csr.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_crt.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_csr.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\xtea.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_utils.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.c" />
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.c" />
+  </ItemGroup>
 </Project>

--- a/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj.filters
+++ b/projects/pc/windows/visual_studio/aws_demos/aws_demos.vcxproj.filters
@@ -1,1296 +1,1308 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<ItemGroup>
-		<Filter Include="freertos_kernel"/>
-		<Filter Include="freertos_kernel\include"/>
-		<Filter Include="freertos_kernel\portable\MSVC-MingW"/>
-		<Filter Include="freertos_kernel\portable"/>
-		<Filter Include="freertos_kernel\portable\MemMang"/>
-		<Filter Include="demos\demo_runner"/>
-		<Filter Include="demos"/>
-		<Filter Include="demos\network_manager"/>
-		<Filter Include="demos\include"/>
-		<Filter Include="libraries\c_sdk\standard\common"/>
-		<Filter Include="libraries\c_sdk\standard"/>
-		<Filter Include="libraries\c_sdk"/>
-		<Filter Include="libraries"/>
-		<Filter Include="libraries\c_sdk\standard\common\include"/>
-		<Filter Include="libraries\c_sdk\standard\common\logging"/>
-		<Filter Include="libraries\c_sdk\standard\common\include\private"/>
-		<Filter Include="libraries\c_sdk\standard\common\include\types"/>
-		<Filter Include="libraries\c_sdk\standard\common\taskpool"/>
-		<Filter Include="libraries\abstractions\platform\include\platform"/>
-		<Filter Include="libraries\abstractions\platform\include"/>
-		<Filter Include="libraries\abstractions\platform"/>
-		<Filter Include="libraries\abstractions"/>
-		<Filter Include="libraries\abstractions\platform\include\types"/>
-		<Filter Include="libraries\abstractions\platform\freertos"/>
-		<Filter Include="libraries\abstractions\platform\freertos\include\platform"/>
-		<Filter Include="libraries\abstractions\platform\freertos\include"/>
-		<Filter Include="libraries\abstractions\secure_sockets\include"/>
-		<Filter Include="libraries\abstractions\secure_sockets"/>
-		<Filter Include="libraries\abstractions\secure_sockets\freertos_plus_tcp"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp"/>
-		<Filter Include="libraries\freertos_plus\standard"/>
-		<Filter Include="libraries\freertos_plus"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\include"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface"/>
-		<Filter Include="libraries\freertos_plus\standard\tls\src"/>
-		<Filter Include="libraries\freertos_plus\standard\tls"/>
-		<Filter Include="libraries\freertos_plus\standard\tls\include"/>
-		<Filter Include="libraries\freertos_plus\standard\crypto\src"/>
-		<Filter Include="libraries\freertos_plus\standard\crypto"/>
-		<Filter Include="libraries\freertos_plus\standard\crypto\include"/>
-		<Filter Include="libraries\freertos_plus\standard\pkcs11\include"/>
-		<Filter Include="libraries\freertos_plus\standard\pkcs11"/>
-		<Filter Include="libraries\freertos_plus\standard\pkcs11\src"/>
-		<Filter Include="vendors\pc\boards\windows\ports\pkcs11"/>
-		<Filter Include="vendors\pc\boards\windows\ports"/>
-		<Filter Include="vendors\pc\boards\windows"/>
-		<Filter Include="vendors\pc\boards"/>
-		<Filter Include="vendors\pc"/>
-		<Filter Include="vendors"/>
-		<Filter Include="libraries\abstractions\pkcs11\mbedtls"/>
-		<Filter Include="libraries\abstractions\pkcs11"/>
-		<Filter Include="libraries\abstractions\pkcs11\include"/>
-		<Filter Include="libraries\freertos_plus\standard\utils\src"/>
-		<Filter Include="libraries\freertos_plus\standard\utils"/>
-		<Filter Include="libraries\freertos_plus\standard\utils\include"/>
-		<Filter Include="demos\dev_mode_key_provisioning\src"/>
-		<Filter Include="demos\dev_mode_key_provisioning"/>
-		<Filter Include="demos\dev_mode_key_provisioning\include"/>
-		<Filter Include="libraries\c_sdk\aws\defender\src"/>
-		<Filter Include="libraries\c_sdk\aws\defender"/>
-		<Filter Include="libraries\c_sdk\aws"/>
-		<Filter Include="libraries\c_sdk\aws\defender\src\private"/>
-		<Filter Include="libraries\c_sdk\aws\defender\include"/>
-		<Filter Include="libraries\c_sdk\standard\mqtt\src"/>
-		<Filter Include="libraries\c_sdk\standard\mqtt"/>
-		<Filter Include="libraries\c_sdk\standard\serializer\src\cbor"/>
-		<Filter Include="libraries\c_sdk\standard\serializer\src"/>
-		<Filter Include="libraries\c_sdk\standard\serializer"/>
-		<Filter Include="libraries\c_sdk\standard\serializer\src\json"/>
-		<Filter Include="libraries\c_sdk\standard\serializer\include"/>
-		<Filter Include="libraries\c_sdk\aws\shadow\src"/>
-		<Filter Include="libraries\c_sdk\aws\shadow"/>
-		<Filter Include="libraries\c_sdk\aws\shadow\include"/>
-		<Filter Include="libraries\c_sdk\standard\https\src"/>
-		<Filter Include="libraries\c_sdk\standard\https"/>
-		<Filter Include="libraries\freertos_plus\aws\greengrass\src"/>
-		<Filter Include="libraries\freertos_plus\aws\greengrass"/>
-		<Filter Include="libraries\freertos_plus\aws"/>
-		<Filter Include="libraries\freertos_plus\aws\greengrass\include"/>
-		<Filter Include="libraries\freertos_plus\aws\ota\include"/>
-		<Filter Include="libraries\freertos_plus\aws\ota"/>
-		<Filter Include="libraries\freertos_plus\aws\ota\src"/>
-		<Filter Include="libraries\3rdparty\mbedtls\library"/>
-		<Filter Include="libraries\3rdparty\mbedtls"/>
-		<Filter Include="libraries\3rdparty"/>
-		<Filter Include="vendors\pc\boards\windows\ports\ota"/>
-		<Filter Include="libraries\freertos_plus\aws\ota\src\mqtt"/>
-		<Filter Include="libraries\freertos_plus\aws\ota\src\http"/>
-		<Filter Include="libraries\abstractions\posix\include\FreeRTOS_POSIX"/>
-		<Filter Include="libraries\abstractions\posix\include"/>
-		<Filter Include="libraries\abstractions\posix"/>
-		<Filter Include="libraries\abstractions\posix\include\FreeRTOS_POSIX\sys"/>
-		<Filter Include="vendors\pc\boards\windows\ports\posix"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_posix\source"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_posix"/>
-		<Filter Include="libraries\freertos_plus\standard\freertos_plus_posix\include"/>
-		<Filter Include="demos\defender"/>
-		<Filter Include="demos\greengrass_connectivity"/>
-		<Filter Include="demos\https"/>
-		<Filter Include="demos\mqtt"/>
-		<Filter Include="demos\ota"/>
-		<Filter Include="demos\shadow"/>
-		<Filter Include="demos\tcp"/>
-		<Filter Include="application_code"/>
-		<Filter Include="libraries\3rdparty\tracealyzer_recorder"/>
-		<Filter Include="libraries\3rdparty\mbedtls\include\mbedtls"/>
-		<Filter Include="libraries\3rdparty\mbedtls\include"/>
-		<Filter Include="libraries\3rdparty\mbedtls_utils"/>
-		<Filter Include="libraries\3rdparty\pkcs11"/>
-		<Filter Include="libraries\3rdparty\tinycbor\src"/>
-		<Filter Include="libraries\3rdparty\tinycbor"/>
-		<Filter Include="libraries\3rdparty\http_parser"/>
-		<Filter Include="libraries\3rdparty\jsmn"/>
-	</ItemGroup>
-	<ItemGroup>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\FreeRTOS.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\StackMacros.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\atomic.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\croutine.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\deprecated_definitions.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\event_groups.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\list.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\message_buffer.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_prototypes.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_wrappers.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\portable.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\projdefs.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\queue.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\semphr.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\stack_macros.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\stream_buffer.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\task.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\include\timers.h">
-			<Filter>freertos_kernel\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\portmacro.h">
-			<Filter>freertos_kernel\portable\MSVC-MingW</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\network_manager\iot_network_manager_private.h">
-			<Filter>demos\network_manager</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_application_version.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential_keys.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_demo.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_iot_demo_network.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\aws_ota_codesigner_certificate.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_config_common.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_demo_logging.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\include\iot_demo_runner.h">
-			<Filter>demos\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_appversion32.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_init.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_linear_containers.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_logging.h">
-			<Filter>libraries\c_sdk\standard\common\include\private</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_task.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_setup.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_network_types.h">
-			<Filter>libraries\c_sdk\standard\common\include\types</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_taskpool.h">
-			<Filter>libraries\c_sdk\standard\common\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_taskpool_types.h">
-			<Filter>libraries\c_sdk\standard\common\include\types</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_taskpool_internal.h">
-			<Filter>libraries\c_sdk\standard\common\include\private</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_clock.h">
-			<Filter>libraries\abstractions\platform\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_network.h">
-			<Filter>libraries\abstractions\platform\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_threads.h">
-			<Filter>libraries\abstractions\platform\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\types\iot_platform_types.h">
-			<Filter>libraries\abstractions\platform\include\types</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_platform_types_freertos.h">
-			<Filter>libraries\abstractions\platform\freertos\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_metrics.h">
-			<Filter>libraries\abstractions\platform\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_network_freertos.h">
-			<Filter>libraries\abstractions\platform\freertos\include\platform</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets.h">
-			<Filter>libraries\abstractions\secure_sockets\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_config_defaults.h">
-			<Filter>libraries\abstractions\secure_sockets\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_wrapper_metrics.h">
-			<Filter>libraries\abstractions\secure_sockets\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_ARP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DHCP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DNS.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_errno_TCP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOSIPConfigDefaults.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP_Private.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Sockets.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Stream_Buffer.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_IP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_WIN.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_UDP_IP.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\IPTraceMacroDefaults.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkBufferManagement.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkInterface.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\include\iot_tls.h">
-			<Filter>libraries\freertos_plus\standard\tls\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\include\iot_crypto.h">
-			<Filter>libraries\freertos_plus\standard\crypto\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include\iot_pkcs11.h">
-			<Filter>libraries\freertos_plus\standard\pkcs11\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\threading_alt.h">
-			<Filter>libraries\abstractions\pkcs11\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\include\iot_pkcs11_pal.h">
-			<Filter>libraries\abstractions\pkcs11\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_system_init.h">
-			<Filter>libraries\freertos_plus\standard\utils\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_pki_utils.h">
-			<Filter>libraries\freertos_plus\standard\utils\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\dev_mode_key_provisioning\include\aws_dev_mode_key_provisioning.h">
-			<Filter>demos\dev_mode_key_provisioning\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\private\aws_iot_defender_internal.h">
-			<Filter>libraries\c_sdk\aws\defender\src\private</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\include\aws_iot_defender.h">
-			<Filter>libraries\c_sdk\aws\defender\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_serializer.h">
-			<Filter>libraries\c_sdk\standard\serializer\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_json_utils.h">
-			<Filter>libraries\c_sdk\standard\serializer\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_iot_shadow.h">
-			<Filter>libraries\c_sdk\aws\shadow\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow_config_defaults.h">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_shadow.h">
-			<Filter>libraries\c_sdk\aws\shadow\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.h">
-			<Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_ggd_config_defaults.h">
-			<Filter>libraries\freertos_plus\aws\greengrass\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_greengrass_discovery.h">
-			<Filter>libraries\freertos_plus\aws\greengrass\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_agent.h">
-			<Filter>libraries\freertos_plus\aws\ota\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_types.h">
-			<Filter>libraries\freertos_plus\aws\ota\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent_internal.h">
-			<Filter>libraries\freertos_plus\aws\ota\src</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.h">
-			<Filter>libraries\freertos_plus\aws\ota\src</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_pal.h">
-			<Filter>libraries\freertos_plus\aws\ota\src</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor_internal.h">
-			<Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.h">
-			<Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.h">
-			<Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.h">
-			<Filter>libraries\freertos_plus\aws\ota\src\http</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\errno.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\fcntl.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\mqueue.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\pthread.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sched.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\semaphore.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\signal.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sys\types.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX\sys</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\time.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\unistd.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\utils.h">
-			<Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\ports\posix\FreeRTOS_POSIX_portable.h">
-			<Filter>vendors\pc\boards\windows\ports\posix</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_types.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_internal.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_portable_default.h">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_tasks.h">
-			<Filter>demos\tcp</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.h">
-			<Filter>application_code</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aes.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aesni.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\arc4.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aria.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1write.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\base64.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bignum.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\blowfish.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bn_mul.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\camellia.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ccm.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\certs.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chacha20.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chachapoly.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\check_config.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cmac.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\compat-1.3.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\config.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ctr_drbg.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\debug.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\des.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\dhm.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdh.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdsa.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecjpake.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy_poll.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\error.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\gcm.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\havege.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hkdf.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hmac_drbg.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md2.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md4.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md5.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\memory_buffer_alloc.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net_sockets.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\nist_kw.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\oid.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\padlock.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pem.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs11.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs12.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs5.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_time.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_util.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\poly1305.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ripemd160.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha1.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha256.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha512.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cache.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ciphersuites.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cookie.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_internal.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ticket.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\threading.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\timing.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\version.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crl.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crt.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_csr.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\xtea.h">
-			<Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.h">
-			<Filter>libraries\3rdparty\mbedtls_utils</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11.h">
-			<Filter>libraries\3rdparty\pkcs11</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11f.h">
-			<Filter>libraries\3rdparty\pkcs11</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11t.h">
-			<Filter>libraries\3rdparty\pkcs11</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.h">
-			<Filter>libraries\3rdparty\http_parser</Filter>
-		</ClInclude>
-		<ClInclude Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.h">
-			<Filter>libraries\3rdparty\jsmn</Filter>
-		</ClInclude>
-	</ItemGroup>
-	<ItemGroup>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\event_groups.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\list.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\queue.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\stream_buffer.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\tasks.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\timers.c">
-			<Filter>freertos_kernel</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\port.c">
-			<Filter>freertos_kernel\portable\MSVC-MingW</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MemMang\heap_4.c">
-			<Filter>freertos_kernel\portable\MemMang</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_network_addr.c">
-			<Filter>demos\demo_runner</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_version.c">
-			<Filter>demos\demo_runner</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo.c">
-			<Filter>demos\demo_runner</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_network_manager.c">
-			<Filter>demos\network_manager</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_demo_network.c">
-			<Filter>demos\network_manager</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_freertos.c">
-			<Filter>demos\demo_runner</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_runner.c">
-			<Filter>demos\demo_runner</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c">
-			<Filter>libraries\c_sdk\standard\common</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c">
-			<Filter>libraries\c_sdk\standard\common\logging</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c">
-			<Filter>libraries\c_sdk\standard\common</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c">
-			<Filter>libraries\c_sdk\standard\common</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool.c">
-			<Filter>libraries\c_sdk\standard\common\taskpool</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool_static_memory.c">
-			<Filter>libraries\c_sdk\standard\common\taskpool</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_clock_freertos.c">
-			<Filter>libraries\abstractions\platform\freertos</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_threads_freertos.c">
-			<Filter>libraries\abstractions\platform\freertos</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_metrics.c">
-			<Filter>libraries\abstractions\platform\freertos</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_network_freertos.c">
-			<Filter>libraries\abstractions\platform\freertos</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\secure_sockets\freertos_plus_tcp\iot_secure_sockets.c">
-			<Filter>libraries\abstractions\secure_sockets\freertos_plus_tcp</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_ARP.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DHCP.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DNS.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_IP.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Sockets.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Stream_Buffer.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_WIN.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_UDP_IP.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement\BufferAllocation_2.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap\NetworkInterface.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\src\iot_tls.c">
-			<Filter>libraries\freertos_plus\standard\tls\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\src\iot_crypto.c">
-			<Filter>libraries\freertos_plus\standard\crypto\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\src\iot_pkcs11.c">
-			<Filter>libraries\freertos_plus\standard\pkcs11\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\pkcs11\iot_pkcs11_pal.c">
-			<Filter>vendors\pc\boards\windows\ports\pkcs11</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\iot_pkcs11_mbedtls.c">
-			<Filter>libraries\abstractions\pkcs11\mbedtls</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_system_init.c">
-			<Filter>libraries\freertos_plus\standard\utils\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_pki_utils.c">
-			<Filter>libraries\freertos_plus\standard\utils\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\aws_dev_mode_key_provisioning.c">
-			<Filter>demos\dev_mode_key_provisioning\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_api.c">
-			<Filter>libraries\c_sdk\aws\defender\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_collector.c">
-			<Filter>libraries\c_sdk\aws\defender\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_mqtt.c">
-			<Filter>libraries\c_sdk\aws\defender\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_v1.c">
-			<Filter>libraries\c_sdk\aws\defender\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_static_memory.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_subscription.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c">
-			<Filter>libraries\c_sdk\standard\mqtt\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_decoder.c">
-			<Filter>libraries\c_sdk\standard\serializer\src\cbor</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_encoder.c">
-			<Filter>libraries\c_sdk\standard\serializer\src\cbor</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_decoder.c">
-			<Filter>libraries\c_sdk\standard\serializer\src\json</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_encoder.c">
-			<Filter>libraries\c_sdk\standard\serializer\src\json</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_serializer_static_memory.c">
-			<Filter>libraries\c_sdk\standard\serializer\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_json_utils.c">
-			<Filter>libraries\c_sdk\standard\serializer\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_api.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_operation.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_parser.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_static_memory.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_subscription.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow.c">
-			<Filter>libraries\c_sdk\aws\shadow\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_client.c">
-			<Filter>libraries\c_sdk\standard\https\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_utils.c">
-			<Filter>libraries\c_sdk\standard\https\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_greengrass_discovery.c">
-			<Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.c">
-			<Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c">
-			<Filter>libraries\freertos_plus\aws\ota\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c">
-			<Filter>libraries\freertos_plus\aws\ota\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\base64.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\ota\aws_ota_pal.c">
-			<Filter>vendors\pc\boards\windows\ports\ota</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c">
-			<Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c">
-			<Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c">
-			<Filter>libraries\freertos_plus\aws\ota\src\http</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_clock.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_mqueue.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_barrier.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_cond.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_mutex.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_sched.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_semaphore.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_timer.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_unistd.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_utils.c">
-			<Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\defender\aws_iot_demo_defender.c">
-			<Filter>demos\defender</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\greengrass_connectivity\aws_greengrass_discovery_demo.c">
-			<Filter>demos\greengrass_connectivity</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_sync.c">
-			<Filter>demos\https</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_async.c">
-			<Filter>demos\https</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_sync.c">
-			<Filter>demos\https</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_async.c">
-			<Filter>demos\https</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_common.c">
-			<Filter>demos\https</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\mqtt\iot_demo_mqtt.c">
-			<Filter>demos\mqtt</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c">
-			<Filter>demos\ota</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\shadow\aws_iot_demo_shadow.c">
-			<Filter>demos\shadow</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_task.c">
-			<Filter>demos\tcp</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\main.c">
-			<Filter>application_code</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.c">
-			<Filter>application_code</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_entropy_hardware_poll.c">
-			<Filter>application_code</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_run-time-stats-utils.c">
-			<Filter>application_code</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcKernelPort.c">
-			<Filter>libraries\3rdparty\tracealyzer_recorder</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcSnapshotRecorder.c">
-			<Filter>libraries\3rdparty\tracealyzer_recorder</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aes.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aesni.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\arc4.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aria.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1parse.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1write.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\bignum.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\blowfish.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\camellia.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ccm.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\certs.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chacha20.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chachapoly.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher_wrap.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cmac.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ctr_drbg.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\debug.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\des.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\dhm.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdh.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdsa.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecjpake.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp_curves.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy_poll.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\error.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\gcm.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\havege.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hkdf.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hmac_drbg.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md2.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md4.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md5.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md_wrap.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\memory_buffer_alloc.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\net_sockets.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\nist_kw.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\oid.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\padlock.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pem.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk_wrap.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs11.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs12.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs5.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkparse.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkwrite.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform_util.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\poly1305.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ripemd160.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa_internal.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha1.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha256.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha512.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cache.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ciphersuites.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cli.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cookie.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_srv.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ticket.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_tls.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\threading.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\timing.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version_features.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_create.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crl.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crt.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_csr.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_crt.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_csr.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\xtea.c">
-			<Filter>libraries\3rdparty\mbedtls\library</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_utils.c">
-			<Filter>libraries\3rdparty\mbedtls_utils</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.c">
-			<Filter>libraries\3rdparty\mbedtls_utils</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c">
-			<Filter>libraries\3rdparty\tinycbor\src</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.c">
-			<Filter>libraries\3rdparty\http_parser</Filter>
-		</ClCompile>
-		<ClCompile Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.c">
-			<Filter>libraries\3rdparty\jsmn</Filter>
-		</ClCompile>
-	</ItemGroup>
+  <ItemGroup>
+    <Filter Include="freertos_kernel" />
+    <Filter Include="freertos_kernel\include" />
+    <Filter Include="freertos_kernel\portable\MSVC-MingW" />
+    <Filter Include="freertos_kernel\portable" />
+    <Filter Include="freertos_kernel\portable\MemMang" />
+    <Filter Include="demos\demo_runner" />
+    <Filter Include="demos" />
+    <Filter Include="demos\network_manager" />
+    <Filter Include="demos\include" />
+    <Filter Include="libraries\c_sdk\standard\common" />
+    <Filter Include="libraries\c_sdk\standard" />
+    <Filter Include="libraries\c_sdk" />
+    <Filter Include="libraries" />
+    <Filter Include="libraries\c_sdk\standard\common\include" />
+    <Filter Include="libraries\c_sdk\standard\common\logging" />
+    <Filter Include="libraries\c_sdk\standard\common\include\private" />
+    <Filter Include="libraries\c_sdk\standard\common\include\types" />
+    <Filter Include="libraries\c_sdk\standard\common\taskpool" />
+    <Filter Include="libraries\abstractions\platform\include\platform" />
+    <Filter Include="libraries\abstractions\platform\include" />
+    <Filter Include="libraries\abstractions\platform" />
+    <Filter Include="libraries\abstractions" />
+    <Filter Include="libraries\abstractions\platform\include\types" />
+    <Filter Include="libraries\abstractions\platform\freertos" />
+    <Filter Include="libraries\abstractions\platform\freertos\include\platform" />
+    <Filter Include="libraries\abstractions\platform\freertos\include" />
+    <Filter Include="libraries\abstractions\secure_sockets\include" />
+    <Filter Include="libraries\abstractions\secure_sockets" />
+    <Filter Include="libraries\abstractions\secure_sockets\freertos_plus_tcp" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp" />
+    <Filter Include="libraries\freertos_plus\standard" />
+    <Filter Include="libraries\freertos_plus" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\include" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface" />
+    <Filter Include="libraries\freertos_plus\standard\tls\src" />
+    <Filter Include="libraries\freertos_plus\standard\tls" />
+    <Filter Include="libraries\freertos_plus\standard\tls\include" />
+    <Filter Include="libraries\freertos_plus\standard\crypto\src" />
+    <Filter Include="libraries\freertos_plus\standard\crypto" />
+    <Filter Include="libraries\freertos_plus\standard\crypto\include" />
+    <Filter Include="libraries\freertos_plus\standard\pkcs11\include" />
+    <Filter Include="libraries\freertos_plus\standard\pkcs11" />
+    <Filter Include="libraries\freertos_plus\standard\pkcs11\src" />
+    <Filter Include="vendors\pc\boards\windows\ports\pkcs11" />
+    <Filter Include="vendors\pc\boards\windows\ports" />
+    <Filter Include="vendors\pc\boards\windows" />
+    <Filter Include="vendors\pc\boards" />
+    <Filter Include="vendors\pc" />
+    <Filter Include="vendors" />
+    <Filter Include="libraries\abstractions\pkcs11\mbedtls" />
+    <Filter Include="libraries\abstractions\pkcs11" />
+    <Filter Include="libraries\abstractions\pkcs11\include" />
+    <Filter Include="libraries\freertos_plus\standard\utils\src" />
+    <Filter Include="libraries\freertos_plus\standard\utils" />
+    <Filter Include="libraries\freertos_plus\standard\utils\include" />
+    <Filter Include="demos\dev_mode_key_provisioning\src" />
+    <Filter Include="demos\dev_mode_key_provisioning" />
+    <Filter Include="demos\dev_mode_key_provisioning\include" />
+    <Filter Include="libraries\c_sdk\aws\defender\src" />
+    <Filter Include="libraries\c_sdk\aws\defender" />
+    <Filter Include="libraries\c_sdk\aws" />
+    <Filter Include="libraries\c_sdk\aws\defender\src\private" />
+    <Filter Include="libraries\c_sdk\aws\defender\include" />
+    <Filter Include="libraries\c_sdk\standard\mqtt\src" />
+    <Filter Include="libraries\c_sdk\standard\mqtt" />
+    <Filter Include="libraries\c_sdk\standard\serializer\src\cbor" />
+    <Filter Include="libraries\c_sdk\standard\serializer\src" />
+    <Filter Include="libraries\c_sdk\standard\serializer" />
+    <Filter Include="libraries\c_sdk\standard\serializer\src\json" />
+    <Filter Include="libraries\c_sdk\standard\serializer\include" />
+    <Filter Include="libraries\c_sdk\aws\shadow\src" />
+    <Filter Include="libraries\c_sdk\aws\shadow" />
+    <Filter Include="libraries\c_sdk\aws\shadow\include" />
+    <Filter Include="libraries\c_sdk\standard\https\src" />
+    <Filter Include="libraries\c_sdk\standard\https" />
+    <Filter Include="libraries\freertos_plus\aws\greengrass\src" />
+    <Filter Include="libraries\freertos_plus\aws\greengrass" />
+    <Filter Include="libraries\freertos_plus\aws" />
+    <Filter Include="libraries\freertos_plus\aws\greengrass\include" />
+    <Filter Include="libraries\freertos_plus\aws\ota\include" />
+    <Filter Include="libraries\freertos_plus\aws\ota" />
+    <Filter Include="libraries\freertos_plus\aws\ota\src" />
+    <Filter Include="libraries\3rdparty\mbedtls\library" />
+    <Filter Include="libraries\3rdparty\mbedtls" />
+    <Filter Include="libraries\3rdparty" />
+    <Filter Include="vendors\pc\boards\windows\ports\ota" />
+    <Filter Include="libraries\freertos_plus\aws\ota\src\mqtt" />
+    <Filter Include="libraries\freertos_plus\aws\ota\src\http" />
+    <Filter Include="libraries\abstractions\posix\include\FreeRTOS_POSIX" />
+    <Filter Include="libraries\abstractions\posix\include" />
+    <Filter Include="libraries\abstractions\posix" />
+    <Filter Include="libraries\abstractions\posix\include\FreeRTOS_POSIX\sys" />
+    <Filter Include="vendors\pc\boards\windows\ports\posix" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_posix\source" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_posix" />
+    <Filter Include="libraries\freertos_plus\standard\freertos_plus_posix\include" />
+    <Filter Include="demos\defender" />
+    <Filter Include="demos\greengrass_connectivity" />
+    <Filter Include="demos\https" />
+    <Filter Include="demos\mqtt" />
+    <Filter Include="demos\ota" />
+    <Filter Include="demos\shadow" />
+    <Filter Include="demos\tcp" />
+    <Filter Include="application_code" />
+    <Filter Include="libraries\3rdparty\tracealyzer_recorder" />
+    <Filter Include="libraries\3rdparty\mbedtls\include\mbedtls" />
+    <Filter Include="libraries\3rdparty\mbedtls\include" />
+    <Filter Include="libraries\3rdparty\mbedtls_utils" />
+    <Filter Include="libraries\3rdparty\pkcs11" />
+    <Filter Include="libraries\3rdparty\tinycbor\src" />
+    <Filter Include="libraries\3rdparty\tinycbor" />
+    <Filter Include="libraries\3rdparty\http_parser" />
+    <Filter Include="libraries\3rdparty\jsmn" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\FreeRTOS.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\StackMacros.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\atomic.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\croutine.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\deprecated_definitions.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\event_groups.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\list.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\message_buffer.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_prototypes.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\mpu_wrappers.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\portable.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\projdefs.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\queue.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\semphr.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\stack_macros.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\stream_buffer.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\task.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\include\timers.h">
+      <Filter>freertos_kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\portmacro.h">
+      <Filter>freertos_kernel\portable\MSVC-MingW</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\network_manager\iot_network_manager_private.h">
+      <Filter>demos\network_manager</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_application_version.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_clientcredential_keys.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_demo.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_iot_demo_network.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\aws_ota_codesigner_certificate.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_config_common.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_demo_logging.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\include\iot_demo_runner.h">
+      <Filter>demos\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_appversion32.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_init.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_linear_containers.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_logging.h">
+      <Filter>libraries\c_sdk\standard\common\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_task.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_logging_setup.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_network_types.h">
+      <Filter>libraries\c_sdk\standard\common\include\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\iot_taskpool.h">
+      <Filter>libraries\c_sdk\standard\common\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\types\iot_taskpool_types.h">
+      <Filter>libraries\c_sdk\standard\common\include\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\common\include\private\iot_taskpool_internal.h">
+      <Filter>libraries\c_sdk\standard\common\include\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_clock.h">
+      <Filter>libraries\abstractions\platform\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_network.h">
+      <Filter>libraries\abstractions\platform\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_threads.h">
+      <Filter>libraries\abstractions\platform\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\types\iot_platform_types.h">
+      <Filter>libraries\abstractions\platform\include\types</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_platform_types_freertos.h">
+      <Filter>libraries\abstractions\platform\freertos\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\include\platform\iot_metrics.h">
+      <Filter>libraries\abstractions\platform\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\platform\freertos\include\platform\iot_network_freertos.h">
+      <Filter>libraries\abstractions\platform\freertos\include\platform</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets.h">
+      <Filter>libraries\abstractions\secure_sockets\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_config_defaults.h">
+      <Filter>libraries\abstractions\secure_sockets\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\secure_sockets\include\iot_secure_sockets_wrapper_metrics.h">
+      <Filter>libraries\abstractions\secure_sockets\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_ARP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DHCP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_DNS.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_errno_TCP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOSIPConfigDefaults.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_IP_Private.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Sockets.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_Stream_Buffer.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_IP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_TCP_WIN.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\FreeRTOS_UDP_IP.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\IPTraceMacroDefaults.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkBufferManagement.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\include\NetworkInterface.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\include\iot_tls.h">
+      <Filter>libraries\freertos_plus\standard\tls\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\include\iot_crypto.h">
+      <Filter>libraries\freertos_plus\standard\crypto\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\include\iot_pkcs11.h">
+      <Filter>libraries\freertos_plus\standard\pkcs11\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\threading_alt.h">
+      <Filter>libraries\abstractions\pkcs11\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\pkcs11\include\iot_pkcs11_pal.h">
+      <Filter>libraries\abstractions\pkcs11\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_system_init.h">
+      <Filter>libraries\freertos_plus\standard\utils\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\include\iot_pki_utils.h">
+      <Filter>libraries\freertos_plus\standard\utils\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\dev_mode_key_provisioning\include\aws_dev_mode_key_provisioning.h">
+      <Filter>demos\dev_mode_key_provisioning\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\private\aws_iot_defender_internal.h">
+      <Filter>libraries\c_sdk\aws\defender\src\private</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\defender\include\aws_iot_defender.h">
+      <Filter>libraries\c_sdk\aws\defender\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_serializer.h">
+      <Filter>libraries\c_sdk\standard\serializer\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\include\iot_json_utils.h">
+      <Filter>libraries\c_sdk\standard\serializer\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_iot_shadow.h">
+      <Filter>libraries\c_sdk\aws\shadow\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow_config_defaults.h">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\include\aws_shadow.h">
+      <Filter>libraries\c_sdk\aws\shadow\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.h">
+      <Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_ggd_config_defaults.h">
+      <Filter>libraries\freertos_plus\aws\greengrass\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\include\aws_greengrass_discovery.h">
+      <Filter>libraries\freertos_plus\aws\greengrass\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_agent.h">
+      <Filter>libraries\freertos_plus\aws\ota\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\include\aws_iot_ota_types.h">
+      <Filter>libraries\freertos_plus\aws\ota\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent_internal.h">
+      <Filter>libraries\freertos_plus\aws\ota\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.h">
+      <Filter>libraries\freertos_plus\aws\ota\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_pal.h">
+      <Filter>libraries\freertos_plus\aws\ota\src</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor_internal.h">
+      <Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.h">
+      <Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.h">
+      <Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.h">
+      <Filter>libraries\freertos_plus\aws\ota\src\http</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\errno.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\fcntl.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\mqueue.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\pthread.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sched.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\semaphore.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\signal.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\sys\types.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\time.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\unistd.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\abstractions\posix\include\FreeRTOS_POSIX\utils.h">
+      <Filter>libraries\abstractions\posix\include\FreeRTOS_POSIX</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\ports\posix\FreeRTOS_POSIX_portable.h">
+      <Filter>vendors\pc\boards\windows\ports\posix</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_types.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_internal.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\include\FreeRTOS_POSIX_portable_default.h">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_tasks.h">
+      <Filter>demos\tcp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.h">
+      <Filter>application_code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aes.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aesni.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\arc4.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\aria.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\asn1write.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\base64.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bignum.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\blowfish.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\bn_mul.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\camellia.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ccm.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\certs.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chacha20.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\chachapoly.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\check_config.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cipher_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\cmac.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\compat-1.3.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\config.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ctr_drbg.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\debug.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\des.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\dhm.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdh.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecdsa.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecjpake.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ecp_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\entropy_poll.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\error.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\gcm.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\havege.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hkdf.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\hmac_drbg.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md2.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md4.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md5.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\md_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\memory_buffer_alloc.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\net_sockets.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\nist_kw.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\oid.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\padlock.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pem.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pk_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs11.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs12.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\pkcs5.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_time.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\platform_util.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\poly1305.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ripemd160.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\rsa_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha1.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha256.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\sha512.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cache.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ciphersuites.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_cookie.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_internal.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\ssl_ticket.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\threading.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\timing.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\version.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crl.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_crt.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\x509_csr.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls\include\mbedtls\xtea.h">
+      <Filter>libraries\3rdparty\mbedtls\include\mbedtls</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.h">
+      <Filter>libraries\3rdparty\mbedtls_utils</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11.h">
+      <Filter>libraries\3rdparty\pkcs11</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11f.h">
+      <Filter>libraries\3rdparty\pkcs11</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\pkcs11\pkcs11t.h">
+      <Filter>libraries\3rdparty\pkcs11</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.h">
+      <Filter>libraries\3rdparty\http_parser</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.h">
+      <Filter>libraries\3rdparty\jsmn</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\commandTask.h">
+      <Filter>application_code</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\runtimeTimer.h">
+      <Filter>application_code</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\event_groups.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\list.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\queue.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\stream_buffer.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\tasks.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\timers.c">
+      <Filter>freertos_kernel</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MSVC-MingW\port.c">
+      <Filter>freertos_kernel\portable\MSVC-MingW</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\freertos_kernel\portable\MemMang\heap_4.c">
+      <Filter>freertos_kernel\portable\MemMang</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_network_addr.c">
+      <Filter>demos\demo_runner</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo_version.c">
+      <Filter>demos\demo_runner</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\aws_demo.c">
+      <Filter>demos\demo_runner</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_network_manager.c">
+      <Filter>demos\network_manager</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\network_manager\aws_iot_demo_network.c">
+      <Filter>demos\network_manager</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_freertos.c">
+      <Filter>demos\demo_runner</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\demo_runner\iot_demo_runner.c">
+      <Filter>demos\demo_runner</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_init.c">
+      <Filter>libraries\c_sdk\standard\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\logging\iot_logging.c">
+      <Filter>libraries\c_sdk\standard\common\logging</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_static_memory_common.c">
+      <Filter>libraries\c_sdk\standard\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\iot_device_metrics.c">
+      <Filter>libraries\c_sdk\standard\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool.c">
+      <Filter>libraries\c_sdk\standard\common\taskpool</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\common\taskpool\iot_taskpool_static_memory.c">
+      <Filter>libraries\c_sdk\standard\common\taskpool</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_clock_freertos.c">
+      <Filter>libraries\abstractions\platform\freertos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_threads_freertos.c">
+      <Filter>libraries\abstractions\platform\freertos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_metrics.c">
+      <Filter>libraries\abstractions\platform\freertos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\platform\freertos\iot_network_freertos.c">
+      <Filter>libraries\abstractions\platform\freertos</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\secure_sockets\freertos_plus_tcp\iot_secure_sockets.c">
+      <Filter>libraries\abstractions\secure_sockets\freertos_plus_tcp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_ARP.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DHCP.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_DNS.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_IP.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Sockets.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_Stream_Buffer.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_IP.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_TCP_WIN.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\FreeRTOS_UDP_IP.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement\BufferAllocation_2.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\BufferManagement</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap\NetworkInterface.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_tcp\source\portable\NetworkInterface\WinPCap</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\tls\src\iot_tls.c">
+      <Filter>libraries\freertos_plus\standard\tls\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\crypto\src\iot_crypto.c">
+      <Filter>libraries\freertos_plus\standard\crypto\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\pkcs11\src\iot_pkcs11.c">
+      <Filter>libraries\freertos_plus\standard\pkcs11\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\pkcs11\iot_pkcs11_pal.c">
+      <Filter>vendors\pc\boards\windows\ports\pkcs11</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\abstractions\pkcs11\mbedtls\iot_pkcs11_mbedtls.c">
+      <Filter>libraries\abstractions\pkcs11\mbedtls</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_system_init.c">
+      <Filter>libraries\freertos_plus\standard\utils\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\utils\src\iot_pki_utils.c">
+      <Filter>libraries\freertos_plus\standard\utils\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\dev_mode_key_provisioning\src\aws_dev_mode_key_provisioning.c">
+      <Filter>demos\dev_mode_key_provisioning\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_api.c">
+      <Filter>libraries\c_sdk\aws\defender\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_collector.c">
+      <Filter>libraries\c_sdk\aws\defender\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_mqtt.c">
+      <Filter>libraries\c_sdk\aws\defender\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\defender\src\aws_iot_defender_v1.c">
+      <Filter>libraries\c_sdk\aws\defender\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_api.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_network.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_operation.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_serialize.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_static_memory.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_subscription.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_validate.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\mqtt\src\iot_mqtt_agent.c">
+      <Filter>libraries\c_sdk\standard\mqtt\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_decoder.c">
+      <Filter>libraries\c_sdk\standard\serializer\src\cbor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\cbor\iot_serializer_tinycbor_encoder.c">
+      <Filter>libraries\c_sdk\standard\serializer\src\cbor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_decoder.c">
+      <Filter>libraries\c_sdk\standard\serializer\src\json</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\json\iot_serializer_json_encoder.c">
+      <Filter>libraries\c_sdk\standard\serializer\src\json</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_serializer_static_memory.c">
+      <Filter>libraries\c_sdk\standard\serializer\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\serializer\src\iot_json_utils.c">
+      <Filter>libraries\c_sdk\standard\serializer\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_api.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_operation.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_parser.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_static_memory.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_iot_shadow_subscription.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\aws\shadow\src\aws_shadow.c">
+      <Filter>libraries\c_sdk\aws\shadow\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_client.c">
+      <Filter>libraries\c_sdk\standard\https\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\c_sdk\standard\https\src\iot_https_utils.c">
+      <Filter>libraries\c_sdk\standard\https\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_greengrass_discovery.c">
+      <Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\greengrass\src\aws_helper_secure_connect.c">
+      <Filter>libraries\freertos_plus\aws\greengrass\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_agent.c">
+      <Filter>libraries\freertos_plus\aws\ota\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\aws_iot_ota_interface.c">
+      <Filter>libraries\freertos_plus\aws\ota\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\base64.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\ports\ota\aws_ota_pal.c">
+      <Filter>vendors\pc\boards\windows\ports\ota</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_cbor.c">
+      <Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\mqtt\aws_iot_ota_mqtt.c">
+      <Filter>libraries\freertos_plus\aws\ota\src\mqtt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\aws\ota\src\http\aws_iot_ota_http.c">
+      <Filter>libraries\freertos_plus\aws\ota\src\http</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_clock.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_mqueue.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_barrier.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_cond.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_pthread_mutex.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_sched.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_semaphore.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_timer.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_unistd.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\freertos_plus\standard\freertos_plus_posix\source\FreeRTOS_POSIX_utils.c">
+      <Filter>libraries\freertos_plus\standard\freertos_plus_posix\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\defender\aws_iot_demo_defender.c">
+      <Filter>demos\defender</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\greengrass_connectivity\aws_greengrass_discovery_demo.c">
+      <Filter>demos\greengrass_connectivity</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_sync.c">
+      <Filter>demos\https</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_download_async.c">
+      <Filter>demos\https</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_sync.c">
+      <Filter>demos\https</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_s3_upload_async.c">
+      <Filter>demos\https</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\https\iot_demo_https_common.c">
+      <Filter>demos\https</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\mqtt\iot_demo_mqtt.c">
+      <Filter>demos\mqtt</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\ota\aws_iot_ota_update_demo.c">
+      <Filter>demos\ota</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\shadow\aws_iot_demo_shadow.c">
+      <Filter>demos\shadow</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\demos\tcp\aws_tcp_echo_client_single_task.c">
+      <Filter>demos\tcp</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\main.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_demo_logging.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_entropy_hardware_poll.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\aws_run-time-stats-utils.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcKernelPort.c">
+      <Filter>libraries\3rdparty\tracealyzer_recorder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tracealyzer_recorder\trcSnapshotRecorder.c">
+      <Filter>libraries\3rdparty\tracealyzer_recorder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aes.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aesni.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\arc4.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\aria.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1parse.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\asn1write.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\bignum.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\blowfish.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\camellia.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ccm.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\certs.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chacha20.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\chachapoly.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cipher_wrap.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\cmac.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ctr_drbg.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\debug.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\des.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\dhm.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdh.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecdsa.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecjpake.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ecp_curves.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\entropy_poll.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\error.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\gcm.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\havege.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hkdf.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\hmac_drbg.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md2.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md4.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md5.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\md_wrap.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\memory_buffer_alloc.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\net_sockets.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\nist_kw.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\oid.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\padlock.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pem.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pk_wrap.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs11.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs12.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkcs5.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkparse.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\pkwrite.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\platform_util.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\poly1305.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ripemd160.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\rsa_internal.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha1.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha256.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\sha512.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cache.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ciphersuites.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cli.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_cookie.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_srv.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_ticket.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\ssl_tls.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\threading.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\timing.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\version_features.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_create.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crl.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_crt.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509_csr.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_crt.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\x509write_csr.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls\library\xtea.c">
+      <Filter>libraries\3rdparty\mbedtls\library</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_utils.c">
+      <Filter>libraries\3rdparty\mbedtls_utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\mbedtls_utils\mbedtls_error.c">
+      <Filter>libraries\3rdparty\mbedtls_utils</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborpretty_stdio.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborencoder_close_container_checked.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborerrorstrings.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\tinycbor\src\cborparser_dup_string.c">
+      <Filter>libraries\3rdparty\tinycbor\src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\http_parser\http_parser.c">
+      <Filter>libraries\3rdparty\http_parser</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\libraries\3rdparty\jsmn\jsmn.c">
+      <Filter>libraries\3rdparty\jsmn</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\commandTask.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\..\vendors\pc\boards\windows\aws_demos\application_code\runtimeTimer.c">
+      <Filter>application_code</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/vendors/pc/boards/windows/aws_demos/application_code/commandTask.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/commandTask.c
@@ -1,0 +1,33 @@
+#include "commandTask.h"
+
+#include <stdio.h>
+
+#include "FreeRTOS.h"
+#include "FreeRTOSIPConfig.h"
+#include "runtimeTimer.h"
+#include "task.h"
+
+#define MAX_COMMAND_LENGTH 3 // only supported command is "rt"
+static uint8_t ucParameterToPass = 0; // Required as part of task creation.
+TaskHandle_t commandTaskHandle = NULL;
+
+void prvCommandTaskCode(void* pvParameters) {
+    char input[MAX_COMMAND_LENGTH];
+
+    for (;;) {
+        scanf("%s", input);
+        if (strcmp(input, "rt") == 0) printRuntime();
+    }
+}
+
+void initializeCommandTask(void)
+{   
+    xTaskCreate(
+        prvCommandTaskCode,
+        "USER_COMMANDS",
+        configMINIMAL_STACK_SIZE,
+        &ucParameterToPass, //ucParameterToPass must exist for the lifetime of the task, even if unused
+        tskIDLE_PRIORITY,
+        &commandTaskHandle);
+    configASSERT(commandTaskHandle);
+}

--- a/vendors/pc/boards/windows/aws_demos/application_code/commandTask.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/commandTask.h
@@ -1,0 +1,2 @@
+/* Function for task for running commands based on user input */
+void initializeCommandTask(void);

--- a/vendors/pc/boards/windows/aws_demos/application_code/main.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/main.c
@@ -58,6 +58,9 @@
 #include "iot_network_manager_private.h"
 #include "aws_iot_network_config.h"
 
+#include "commandTask.h"
+#include "runtimeTimer.h"
+
 /* Define a name that will be used for LLMNR and NBNS searches. Once running,
  * you can "ping RTOSDemo" instead of pinging the IP address, which is useful when
  * using DHCP. */
@@ -119,6 +122,9 @@ int main( void )
      * but a DHCP server cannot be contacted. */
 	FreeRTOS_printf(("FreeRTOS_IPInit\n"));
 	vApplicationIPInit();
+
+    initializeRuntimeTimer();
+    initializeCommandTask();
 
     /* Start the RTOS scheduler. */
     FreeRTOS_printf( ( "vTaskStartScheduler\n" ) );
@@ -302,12 +308,3 @@ static void prvSaveTraceFile( void )
         printf( "\r\nFailed to create trace dump file\r\n" );
     }
 }
-/*-----------------------------------------------------------*/
-
-void getUserCmd( char * pucUserCmd )
-{
-    char cTmp;
-
-    scanf( "%c%c", pucUserCmd, &cTmp );
-}
-/*-----------------------------------------------------------*/

--- a/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.c
+++ b/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.c
@@ -1,0 +1,70 @@
+#include "runtimeTimer.h"
+
+#include "FreeRTOS.h"
+#include "FreeRTOSIPConfig.h"
+#include "task.h"
+#include "timers.h"
+
+#define MS_PER_MINUTE (SECONDS_PER_MINUTE * MS_PER_SECOND)
+#define SECONDS_PER_MINUTE (60)
+#define MS_PER_SECOND (1000)
+
+#define RUNTIME_TASK_INTERRUPT_NUMBER (3)
+
+volatile unsigned long long runtime_ms = 0;
+static StaticTimer_t xRuntimeTimerBuffer[configMINIMAL_STACK_SIZE];
+static unsigned long runtimeTimerId = 1004; // Arbitrary value
+// portTICK_PERIOD_MS is 1. Windows Simulator Tick is 1kHZ.
+const TickType_t xDelay = 1 / portTICK_PERIOD_MS; 
+
+uint32_t runtimeInterrupt(void)
+{
+    runtime_ms += xDelay;
+    return 0;
+}
+
+void prvRuntimeTimerCallback(TimerHandle_t xTimer)
+{
+    vPortGenerateSimulatedInterrupt(RUNTIME_TASK_INTERRUPT_NUMBER);
+}
+
+void initializeRuntimeTimer(void) {
+    BaseType_t xResult;
+    runtime_ms = 0;
+
+    TimerHandle_t runtimeTimer = xTimerCreateStatic(
+        "Runtime", /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+        xDelay,
+        pdTRUE,
+        (void *) &runtimeTimerId,
+        prvRuntimeTimerCallback,
+        xRuntimeTimerBuffer);
+    vPortSetInterruptHandler(RUNTIME_TASK_INTERRUPT_NUMBER, runtimeInterrupt);
+
+    // Initialize runtime timer before starting scheduler, to avoid using a block time
+    xResult = xTimerStart(runtimeTimer, 0); 
+    FreeRTOS_printf( (xResult == pdPASS ?
+        "Runtime Timer Initialized" :
+        "Runtime Timer Init Failed") );
+}
+
+void printRuntime(void) {
+    // Copy the global variable to avoid race condition during processing.
+    unsigned long long local_copy = runtime_ms;
+
+    unsigned long rt_1 = portGET_RUN_TIME_COUNTER_VALUE();
+
+    unsigned long minutes = (unsigned long) local_copy / MS_PER_MINUTE;
+    unsigned int seconds = (unsigned int) (local_copy % MS_PER_MINUTE) / MS_PER_SECOND;
+    unsigned int milliseconds = (unsigned int) local_copy % MS_PER_SECOND;
+    FreeRTOS_printf( ("Timer-Based Runtime: %ld:%02ld:%03d\r\n", minutes, seconds, milliseconds) );
+
+    unsigned long rt_2= portGET_RUN_TIME_COUNTER_VALUE();
+    FreeRTOS_printf(("Latency: %ld.%02ldms\r\n", (rt_2 - rt_1) / 100, (rt_2 - rt_1) % 100));
+
+    unsigned long  windows_ticks_ms = rt_1 / 100;
+    minutes = (unsigned long)windows_ticks_ms / MS_PER_MINUTE;
+    seconds = (unsigned int)(windows_ticks_ms % MS_PER_MINUTE) / MS_PER_SECOND;
+    milliseconds = (unsigned int)windows_ticks_ms % MS_PER_SECOND;
+    FreeRTOS_printf(("Windows-Tick Runtime: %ld:%02ld:%03d\r\n", minutes, seconds, milliseconds));
+}

--- a/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.h
+++ b/vendors/pc/boards/windows/aws_demos/application_code/runtimeTimer.h
@@ -1,0 +1,8 @@
+#pragma once
+/* Function for intializing runtime timer based on timer task.
+   This function must be called before vTaskStartScheduler is called*/
+void initializeRuntimeTimer(void);
+
+/* Prints the current runtime of the simulator, based on timer task
+   in MINUTES:SECONDS:MILLSECONDS format, with leading 0's*/
+void printRuntime(void);


### PR DESCRIPTION
Implemented runtime timer command

Description
-----------
For this feature, I was required to "[u]se the FreeRTOS Windows Simulator to output a formatted clock string (minutes, seconds, milliseconds) using a periodic interrupt for the time base", with "[b]onus points for demonstrating latency between interrupt and task print."

I implemented a runtime timer using the timer task and simulated interrupts, but the simulated interrupts had to be triggered in a timing task. [[1]](https://www.freertos.org/FreeRTOS-Windows-Simulator-Emulator-for-Visual-Studio-and-Eclipse-MingW.html)
In the Windows simulator, there is no way to configure a periodic hardware interrupt, and with FreeRTOS development in general, interrupts are a hardware feature that needs to be managed against the software stack. [[2]](https://www.freertos.org/wp-content/uploads/2018/07/161204_Mastering_the_FreeRTOS_Real_Time_Kernel-A_Hands-On_Tutorial_Guide.pdf#page=209)

In testing, I found that the runtime calculated by the simulated periodic interrupt was slower than the real time. In `aws_run-time-stats-utils.c`, I found this comment:
` Note that this is a simulated port, where simulated time is a lot slower than real time, therefore the run time counter values have no real meaningful units.`

This file uses the Windows System Tick to calculate a more accurate real runtime, so I used that to calculate the latency. Furthermore, I could not calculate the latency between the periodic-timer-based runtime and the print because the periodic-timer was not firing during the `printf` call. I need help investigating this issue. My initial hunch is that task priority does not apply in the Windows Simulator. I believe this because the periodic-timer firing at 1ms in a system with a 1kHz systick should be starving the entire system. It does not.

I added and kept the more accurate runtime based on Windows' System Ticks that was found during the latency testing.

I created a new task for handling user commands, and added the "rt" command to print out the runtime. This was the most intuitive method of testing the changes I made.

I did not add any unit tests or run a linter.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] My code is Linted.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.